### PR TITLE
Added documentation for automatic links

### DIFF
--- a/Support/help.markdown
+++ b/Support/help.markdown
@@ -17,6 +17,10 @@ Reference-style labels (titles are optional):
 	
 	  [id]: http://example.com/  "Title"
 
+Automatic:
+
+	<http://example.com>
+
 
 ## Images ##
 


### PR DESCRIPTION
This feature is somewhat hidden in the official Markdown documentation (it's near the end, at "Miscellaneous") but here it was fully hidden because it wasn't mentioned at all.