### PR TITLE
Remove MathJax support.

### DIFF
--- a/Commands/Markdown preview.plist
+++ b/Commands/Markdown preview.plist
@@ -31,24 +31,6 @@ TextMate::HTMLOutput.show(:title =&gt; "Markdown Preview", :sub_title =&gt; ENV[
   end
 
   io &lt;&lt; lines.join("\n")
-  if ENV["TM_MARKDOWN_MATHJAX"].to_i &gt; 0
-      io &lt;&lt; %{
-        &lt;script type="text/x-mathjax-config"&gt;
-          MathJax.Hub.Config({
-            extensions: ["tex2jax.js"],
-            jax: ["input/TeX", "output/HTML-CSS"],
-            tex2jax: {
-              inlineMath: [ ["$","$"], ["\\\\(","\\\\)"] ],
-              displayMath: [ ["$$","$$"], ["\\\\[","\\\\]"] ],
-              processEscapes: false
-            },
-            "HTML-CSS": { availableFonts: ["TeX"] }
-          });
-        &lt;/script&gt;
-        &lt;script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"&gt;
-        &lt;/script&gt;
-      }
-  end
   io &lt;&lt; "\n&lt;script&gt;window.location.hash = \"scroll_to_here\";&lt;/script&gt;"
 end
 


### PR DESCRIPTION
This functionality has been extracted into its own bundle: https://github.com/noniq/Markdown-MathJax.tmbundle

See https://github.com/textmate/bundle-support.tmbundle/pull/19#issuecomment-237811387 ff. for rationale.