### PR TITLE
If project directory is set, use it as working directory.

### DIFF
--- a/Commands/Markdown preview.plist
+++ b/Commands/Markdown preview.plist
@@ -11,6 +11,16 @@ require "#{ENV["TM_SUPPORT_PATH"]}/lib/tm/htmloutput"
 require "#{ENV["TM_SUPPORT_PATH"]}/lib/tm/markdown"
 
 TextMate::HTMLOutput.show(:title =&gt; "Markdown Preview", :sub_title =&gt; ENV["TM_FILENAME"]) do |io|
+  if ENV['TM_PROJECT_DIRECTORY']
+    # Run the Markdown command with the project directory as working dir: If you
+    # have for example a Ruby project using the Redcarpet gem, you can set
+    # `TM_MARKDOWN` to `"bundle exec redcarpet"` (optionally specifying additional
+    # command line options for configuration) in the project’s
+    # `.tm_properties` to use this exact version of Redcarpet for the preview
+    # command.
+    Dir.chdir ENV['TM_PROJECT_DIRECTORY']
+  end
+
   if ENV["TM_FILEPATH"] &amp;&amp; File.exists?(ENV["TM_FILEPATH"])
     io &lt;&lt; "&lt;base href='file://#{URI.escape ENV["TM_FILEPATH"]}'&gt;\n"
   end


### PR DESCRIPTION
This allows to use project-specific Markdown processors: If you have for example a Ruby project using the Redcarpet gem, you can now set `TM_MARKDOWN` to `"bundle exec redcarpet"` (optionally specifying additional command line options for configuration) in the project’s `.tm_properties` to use this exact version of Redcarpet for the preview command.