### PR TITLE
Fix bug that omitted content from a preview

### DIFF
--- a/Commands/Markdown preview.plist
+++ b/Commands/Markdown preview.plist
@@ -40,8 +40,8 @@ TextMate::HTMLOutput.show(:title =&gt; "Markdown Preview", :sub_title =&gt; ENV[
     n -= 1
   end
 
-  if n &gt; 0 &amp;&amp; m = lines[n].match(/&lt;(h\d|p|ul|li|blockquote|pre|div|img|code|table|tr)&gt;(.*)$/i)
-    lines[n] = "&lt;#{m[1]} id=\"scroll_to_here\" &gt;#{m[2]}"
+  if n &gt; 0 &amp;&amp; m = lines[n].match(/^(.*)&lt;(h\d|p|ul|li|blockquote|pre|div|img|code|table|tr)&gt;(.*)$/i)
+    lines[n] = "#{m[1]}&lt;#{m[2]} id=\"scroll_to_here\" &gt;#{m[3]}"
   end
 
   io &lt;&lt; lines.join("\n")


### PR DESCRIPTION
This patch solves a glitch I incurred enough times to make me look into it.

When the `scroll_to_here` mark is applied to an element by the `Markdown preview` command, whatever is between  /^/ and the opening tag disappears from the output.

The problem is that the code injecting `id="scroll_to_here"` ignores anything before the matching tag.

For example, if we preview the following text while keeping the cursor on line 8, the piece of text "repellat ut et" on line 2 gets lost.

```markdown
1  Alias nihil quo culpa non architecto est dicta doloremque. Praesentium
2  repellat ut et `neque` excepturi sint ab sint. Tenetur similique voluptas
3  delectus aspernatur et debitis deleniti perferendis. Aut hic eos ipsum
4  corrupti in. Qui quam cumque sint voluptatem magni debitis et. Quam rerum
5  possimus non et.
6  
7  
8  |
```

```html
<p>Alias nihil quo culpa non architecto est dicta doloremque. Praesentium
<code id="scroll_to_here">neque</code> excepturi sint ab sint. Tenetur similique voluptas
delectus aspernatur et debitis deleniti perferendis. Aut hic eos ipsum
corrupti in. Qui quam cumque sint voluptatem magni debitis et. Quam rerum
possimus non et.</p>
```