### PR TITLE
Tribute to macOS markdown icon

### DIFF
--- a/Snippets/Think different.plist
+++ b/Snippets/Think different.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>content</key>
+	<string># [Think different][]
+
+# Here's to the crazy ones.
+
+1. The misfits
+2. The rebels
+3. The troublemakers
+
+The round pegs in the square holes. The ones who see things differently. The're not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can't do is ignore them. Because they change things.
+
+***They push the human race forward***.
+
+And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.
+
+[Think different]: https://web.archive.org/web/20010228171255/http://www.apple.com/thinkdifferent/
+</string>
+	<key>name</key>
+	<string>Think Different</string>
+	<key>scope</key>
+	<string>text.html.markdown</string>
+	<key>tabTrigger</key>
+	<string>demo</string>
+	<key>uuid</key>
+	<string>17F9D43B-EAFF-4003-8645-CA8BC4326A79</string>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -10,6 +10,10 @@
 	<string>&lt;a href="http://daringfireball.net/projects/markdown/"&gt;Markdown&lt;/a&gt; allows you to write using an easy-to-read, easy-to-write plain text format, then convert it to structurally valid XHTML. This bundle provides preview functionality, syntax highlighting, and several useful commands.</string>
 	<key>mainMenu</key>
 	<dict>
+		<key>excludedItems</key>
+		<array>
+			<string>17F9D43B-EAFF-4003-8645-CA8BC4326A79</string>
+		</array>
 		<key>items</key>
 		<array>
 			<string>B52DEA16-8480-11D9-BE59-000D93B3A10E</string>


### PR DESCRIPTION
Added a hidden text-snippet, celebrating the new macOS markdown icon.

In a markdown-document, type `demo` followed by the <kbd>tab</kbd>-key. This will expand to the think-different snippet.

In the new icon, the hyperlink reference is not used. This has been fixed. And the link points to the original page on apples website, archived by archive.org.

See: <https://twitter.com/zhcet4/status/1280149112432791552>
